### PR TITLE
Adjust the comment/documentation to be consistent

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,10 +4,10 @@ var GoogleStrategy = require('passport-google-oauth20');
 var db = require('../db');
 
 
-// Configure the Facebook strategy for use by Passport.
+// Configure the Google strategy for use by Passport.
 //
 // OAuth 2.0-based strategies require a `verify` function which receives the
-// credential (`accessToken`) for accessing the Facebook API on the user's
+// credential (`accessToken`) for accessing the Google API on the user's
 // behalf, along with the user's profile.  The function must invoke `cb`
 // with a user object, which will be set at `req.user` in route handlers after
 // authentication.
@@ -60,7 +60,7 @@ function(accessToken, refreshToken, profile, cb) {
 // production-quality application, this would typically be as simple as
 // supplying the user ID when serializing, and querying the user record by ID
 // from the database when deserializing.  However, due to the fact that this
-// example does not have a database, the complete Facebook profile is serialized
+// example does not have a database, the complete Google profile is serialized
 // and deserialized.
 passport.serializeUser(function(user, cb) {
   process.nextTick(function() {


### PR DESCRIPTION
The vendor name is rewritten to be Google from Facebook